### PR TITLE
fix github workflow issues

### DIFF
--- a/openapi_client/models/components_schemas_metadata_error.py
+++ b/openapi_client/models/components_schemas_metadata_error.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import Optional, Dict, Any
 from pydantic import BaseModel, Field, StrictStr
 
 class ComponentsSchemasMetadataError(BaseModel):


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `ComponentsSchemasMetadataError` model in the `openapi_client/models/components_schemas_metadata_error.py` file, expanding its type hints for future flexibility.

* [`openapi_client/models/components_schemas_metadata_error.py`](diffhunk://#diff-59139cf90d735f3b0643834a3ab0a05f5b8e04b5a230d8ebbdc01e84254a4e23L21-R21): Added `Dict` and `Any` to the type hints import, enabling the model to support more complex data structures if needed.